### PR TITLE
Add nf-schema, remove unnecessary parameters and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,25 +30,23 @@ Uses Dorado for basecalling and demultiplexing.
 
 ## Pipeline Parameters
 
-| Parameter                         | Required | Default                            | Description                                                                                     |
-| --------------------------------- | -------- | ---------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `experiment_name`                 | No       | -                                  | Name of the experiment, used for final reports (title and filename).                            |
-| `data_dir`                        | Yes      | -                                  | Path to the directory containing POD5 files.                                                    |
-| `sample_data`                     | Yes      | `input/samples.csv`                | Path to the CSV file containing the sample data (required if demultiplexing).                   |
-| `output_dir`                      | No       | `demultiplex_results`              | Directory for saving results.                                                                   |
-| `fastq_output`                    | No       | `true`                             | Generates FASTQ files if `true`; otherwise, generates UBAM files.                               |
-| `qscore_filter`                   | No       | `10`                               | Minimum QScore threshold for "pass" data, used in demultiplexing.                               |
-| `dorado_basecalling_model`        | No       | `sup`                              | Model used for basecalling. Check Dorado help for available options.                            |
-| `dorado_basecalling_extra_config` | No       | -                                  | Additional configuration options for Dorado basecalling.                                        |
-| `dorado_basecalling_gpus`         | No       | `1`                                | Number of GPUs to allocate for basecalling.                                                     |
-| `skip_demultiplexing`             | No       | `false`                            | Skips demultiplexing if `true`.                                                                 |
-| `dorado_demux_kit`                | No       | `EXP-NBD196`                       | Kit identifier used for demultiplexing.                                                         |
-| `dorado_demux_both_ends`          | No       | `false`                            | Demultiplexes using barcodes on both ends (5' and 3') if `true`.                                |
-| `dorado_demux_extra_config`       | No       | -                                  | Additional configuration options for Dorado demultiplexing.                                     |
-| `use_dorado_container`            | No       | `true`                             | Uses Dorado via container if `true`; expects a local installation if `false`.                   |
-| `qc_tools`                        | No       | `['fastqc', 'nanoq', 'toulligqc']` | Specifies which QC tools to run. Options: 'nanoq', 'nanoplot', 'fastqc', 'toulligqc', 'pycoqc'. |
+| Parameter                  | Required | Default                            | Description                                                                                     |
+| -------------------------- | -------- | ---------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `experiment_name`          | No       | -                                  | Name of the experiment, used for final reports (title and filename).                            |
+| `data_dir`                 | Yes      | -                                  | Path to the directory containing POD5 files.                                                    |
+| `sample_data`              | No       | -                                  | Path to the CSV file containing the sample data (if not provided, will not perform demux).      |
+| `output_dir`               | No       | `demultiplex_results`              | Directory for saving results.                                                                   |
+| `fastq_output`             | No       | `true`                             | Generates FASTQ files if `true`; otherwise, generates UBAM files.                               |
+| `qscore_filter`            | No       | `10`                               | Minimum QScore threshold for "pass" data, used in demultiplexing.                               |
+| `dorado_basecalling_model` | No       | `sup`                              | Model used for basecalling. Check Dorado help for available options.                            |
+| `dorado_basecalling_gpus`  | No       | `1`                                | Number of GPUs to allocate for basecalling.                                                     |
+| `dorado_demux_kit`         | No       | `EXP-NBD196`                       | Kit identifier used for demultiplexing.                                                         |
+| `dorado_demux_both_ends`   | No       | `false`                            | Demultiplexes using barcodes on both ends (5' and 3') if `true`.                                |
+| `use_dorado_container`     | No       | `true`                             | Uses Dorado via container if `true`; expects a local installation if `false`.                   |
+| `qc_tools`                 | No       | `['fastqc', 'nanoq', 'toulligqc']` | Specifies which QC tools to run. Options: 'nanoq', 'nanoplot', 'fastqc', 'toulligqc', 'pycoqc'. |
 
 ## Considerations
 
 - The pipeline is compatible with SLURM clusters; use `-profile slurm`.
 - GPU resources are required for basecalling. On SLURM, ensure jobs request GPUs with the `--gres=gpu:X` option.
+- You can provide extra args to dorado basecalling and demultiplexing using `ext.args`.

--- a/assets/samples_data_schema.json
+++ b/assets/samples_data_schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "barcode": { "type": "string" },
+      "sample": { "type": "string" }
+    }
+  }
+}

--- a/conf/params.config
+++ b/conf/params.config
@@ -1,17 +1,15 @@
 params {
 	experiment_name = ''
 	data_dir = null
-	sample_data = 'input/samples.csv'
-	output_dir = 'demultiplex_results/'
+	sample_data = null
+	output_dir = 'results/'
 	fastq_output = true
 	qscore_filter = 10
 	dorado_basecalling_model = 'sup'
-	dorado_basecalling_extra_config = ''
 	dorado_basecalling_gpus = 1
-	skip_demultiplexing = false
 	dorado_demux_kit = 'SQK-NBD114-96'
 	dorado_demux_both_ends = false
-	dorado_demux_extra_config = ''
 	use_dorado_container = true
 	qc_tools = ['fastqc', 'nanoq', 'toulligqc']
+	showHidden = false
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,15 +1,29 @@
+plugins {
+  id 'nf-schema@2.1.0'
+}
+
+validation {
+  help {
+    enabled    = true
+    showHidden = false
+  }
+  ignoreParams = ['showHidden', 'show-hidden']
+}
+
 resume = true
 
 process {
   errorStrategy = 'finish'
 }
 
-report {
-  enabled = true
-  file = "${params.output_dir}/reports/nextflow_report.html"
-  overwrite = true
-}
 
 includeConfig 'conf/params.config'
 includeConfig 'conf/profiles.config'
 includeConfig 'conf/containers.config'
+
+
+def trace_timestamp = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
+report {
+  enabled = true
+  file    = "${params.output_dir}/reports/execution_report_${trace_timestamp}.html"
+}

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com//master/nextflow_schema.json",
+  "title": " pipeline parameters",
+  "description": "",
+  "type": "object",
+  "properties": {
+    "experiment_name": {
+      "type": "string",
+      "description": "Name of the experiment, used for final reports (title and filename)."
+    },
+    "data_dir": {
+      "type": "string",
+      "description": "Path to the directory containing POD5 files.",
+      "format": "directory-path"
+    },
+    "sample_data": {
+      "type": "string",
+      "default": "input/samples.csv",
+      "format": "file-path",
+      "schema": "/assets/samples_data_schema.json",
+      "mimetype": "text/csv",
+      "description": "Path to the CSV file containing the sample data (if not provided, will not perform demux)."
+    },
+    "output_dir": {
+      "type": "string",
+      "default": "results/",
+      "description": "Directory for saving results."
+    },
+    "fastq_output": {
+      "type": "boolean",
+      "default": true,
+      "description": "Generates FASTQ files if `true`; otherwise, generates UBAM files."
+    },
+    "qscore_filter": {
+      "type": "integer",
+      "default": 10,
+      "description": "Minimum QScore threshold for \"pass\" data, used in demultiplexing."
+    },
+    "dorado_basecalling_model": {
+      "type": "string",
+      "default": "sup",
+      "description": "Model used for basecalling. Check Dorado help for available options."
+    },
+    "dorado_basecalling_gpus": {
+      "type": "integer",
+      "default": 1,
+      "description": "Number of GPUs to allocate for basecalling."
+    },
+    "dorado_demux_kit": {
+      "type": "string",
+      "default": "SQK-NBD114-96",
+      "description": "Kit identifier used for demultiplexing."
+    },
+    "dorado_demux_both_ends": {
+      "type": "boolean",
+      "description": "Demultiplexes using barcodes on both ends (5' and 3') if `true`."
+    },
+    "use_dorado_container": {
+      "type": "boolean",
+      "default": true,
+      "description": "Uses Dorado via container if `true`; expects a local installation if `false`."
+    },
+    "qc_tools": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["nanoq", "nanoplot", "fastqc", "toulligqc", "pycoqc"]
+      },
+      "description": "Specifies which QC tools to run."
+    }
+  },
+  "required": ["data_dir"]
+}

--- a/params.example.yml
+++ b/params.example.yml
@@ -5,12 +5,9 @@ output_dir: demultiplex_results/
 fastq_output: true
 qscore_filter: 10
 dorado_basecalling_model: sup
-dorado_basecalling_extra_config: ''
 dorado_basecalling_gpus: 1
-skip_demultiplexing: false
 dorado_demux_kit: SQK-NBD114-96
 dorado_demux_both_ends: false
-dorado_demux_extra_config: ''
 use_dorado_container: true
 qc_tools:
   - fastqc

--- a/subworkflows/reports.nf
+++ b/subworkflows/reports.nf
@@ -62,9 +62,14 @@ process toulligQC {
   tuple val('ToulligQC'), eval('toulligqc --version'), topic: versions
   
   script:
-  report_filename = "${slugify(params.experiment_name)}_toulligqc.html"
-  barcode_list = ["NB23", "NB24"]
-  barcodes_opt = !params.skip_demultiplexing && barcode_list
+  if (params.experiment_name) {
+    report_filename = "${slugify(params.experiment_name)}_toulligqc.html"
+    name_opt = "--report-name ${params.experiment_name}"
+  } else {
+    report_filename = "toulligqc.html"
+    name_opt = ''
+  }
+  barcodes_opt = params.sample_data && barcode_list
     ? "--barcoding --barcodes ${barcode_list.join(',')}"
     : ''
   """
@@ -74,8 +79,8 @@ process toulligQC {
     --sequencing-summary-source sequencing_summary.mod.txt \
     --pod5-source ${data_dir} \
     --html-report-path ${report_filename} \
-    --report-name ${params.experiment_name} \
     --qscore-threshold ${params.qscore_filter} \
+    ${name_opt} \
     ${barcodes_opt}
   """
 }


### PR DESCRIPTION
Improvements:
- Add nf-schema validation
- Remove parameters `dorado_basecalling_extra_config` and `dorado_demux_extra_config`: the prefered now will be using `ext.args`, and the last one will 
- Removed parameter `skip_demultiplexing`: now demultiplexing will be skipped if `sample_data` was not provided.
- Enable nextflow report by default

Fixes:
- Barcodes were hardcoded in ToulligQC
- ToulligQC thowed an error if `experiment_name`  was not defined